### PR TITLE
Add some new properties to the CoapClient class

### DIFF
--- a/CoAP.NET/CoapClient.cs
+++ b/CoAP.NET/CoapClient.cs
@@ -76,6 +76,16 @@ namespace Com.AugustCellars.CoAP
         public Uri Uri { get; set; }
 
         /// <summary>
+        /// Path elements to be added to the URI as Uri-Path options
+        /// </summary>
+        public String UriPath { get; set; }
+
+        /// <summary>
+        /// Query elements to be added tothe URI as Uri-Query options
+        /// </summary>
+        public String UriQuery { get; set; }
+
+        /// <summary>
         /// Gets or sets the endpoint this client is supposed to use.
         /// </summary>
         public IEndPoint EndPoint { get; set; }
@@ -94,6 +104,11 @@ namespace Com.AugustCellars.CoAP
         /// If a non-legal value is given, then it will be rounded to a legal value.
         /// </summary>
         public int Blockwise { get; set; }
+
+        /// <summary>
+        /// OSCOAP context to use for the message
+        /// </summary>
+        public OSCOAP.OscoapOption Oscoap { get; set; }
 
         /// <summary>
         /// Let the client use Confirmable requests.
@@ -575,6 +590,15 @@ namespace Com.AugustCellars.CoAP
         {
             request.Type = _type;
             request.URI = Uri;
+            request.Oscoap = Oscoap;
+
+            if (UriPath != null) {
+                request.UriPath = UriPath;
+            }
+
+            if (UriQuery != null) {
+                request.AddUriQuery(UriQuery);
+            }
             
             if (Blockwise != 0) {
                 request.SetBlock2(BlockOption.EncodeSZX(Blockwise), false, 0);

--- a/CoAP.NET/CoapClient.cs
+++ b/CoAP.NET/CoapClient.cs
@@ -597,7 +597,7 @@ namespace Com.AugustCellars.CoAP
             }
 
             if (UriQuery != null) {
-                request.AddUriQuery(UriQuery);
+                request.UriQuery = UriQuery;
             }
             
             if (Blockwise != 0) {

--- a/CoAP.Test/CoapClientTest.cs
+++ b/CoAP.Test/CoapClientTest.cs
@@ -229,6 +229,10 @@ namespace Com.AugustCellars.CoAP
 
             Response r = client.Get();
             Assert.AreEqual("/abc?upper_case", r.PayloadString);
+
+            client.UriQuery = "upper_case&lower_case";
+            r = client.Get();
+            Assert.AreEqual("/abc?upper_case&lower_case", r.PayloadString);
         }
 
         private void Fail(CoapClient.FailReason reason)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Reviews and suggestions would be appreciated.
 Copyright (c) 2011-2015, Longxiang He <longxianghe@gmail.com>,
 SmeshLink Technology Co.
 
+
 ## Content
 
 - [Quick Start](#quick-start)
@@ -63,16 +64,17 @@ To receive responses asynchronously, register a event handler to
 the event <code>request.Respond</code> before executing.
 
 > #### Parsing Link Format
-> Use <code>LinkFormat.Parse(String)</code> to parse a link-format
+Use <code>LinkFormat.Parse(String)</code> to parse a link-format
   response. The returned enumeration of <code>WebLink</code>
   contains all resources stated in the given link-format string.
-> ```csharp
+  
+```csharp
   Request request = new Request(Method.GET);
   request.URI = new Uri("coap://[::1]/.well-known/core");
   request.Send();
   Response response = request.WaitForResponse();
   IEnumerable<WebLink> links = LinkFormat.Parse(response.PayloadString);
-  ```
+```
 
 See [CoAP Example Client](CoAP.Client) for more.
 


### PR DESCRIPTION
Two new properties added tothe CoapClient class to make life easier when
programming with these classes.

UriPath - create a property that holds a relative path to the main URI
in Uri.  This means that one can create the class with just the server
name and then use this to access different resources on the sever

UriQuery - create a property that holds a query string to be added to
the Uri when the message is sent.